### PR TITLE
Allow ModuleDockingNode if only IJointLockState

### DIFF
--- a/ReCoupler/ReCouplerUtils.cs
+++ b/ReCoupler/ReCouplerUtils.cs
@@ -432,8 +432,18 @@ namespace ReCoupler
             if (!allowKASJoints && isKASPart(part))
                 return true;
             // Accounts for ModuleGrappleNode and all of the Breaking Ground joints and servos.
-            if (!allowRoboJoints && !isKASPart(part) && (part.FindModuleImplementing<IJointLockState>() != null))
-                return true;
+            if (!allowRoboJoints && !isKASPart(part)) {
+                var mods =  part.FindModulesImplementing<IJointLockState>();
+                bool haveNonDockingNode = false;
+                for (int i = mods.Count; i-- > 0; ) {
+                    if (!(mods[i] is ModuleDockingNode)) {
+                        haveNonDockingNode = true;
+                        break;
+                    }
+                }
+                if (haveNonDockingNode)
+                    return true;
+            }
             return false;
         }
 


### PR DESCRIPTION
Recent KSP added IJointLockState to ModuleDockingNode making inline
docking port parts ineligible. This allows such parts so long as
ModuleDockingNode is the only part module implementing IJointLockState.